### PR TITLE
Enable the dualboot feature:

### DIFF
--- a/lib/bootboot/enable_dual_booting.rb
+++ b/lib/bootboot/enable_dual_booting.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DefinitionPatch
+  def initialize(*)
+    lockfile = Pathname.new("#{Bundler::SharedHelpers.default_gemfile}_next.lock")
+    super
+  end
+end
+
+if ENV['SHOPIFY_NEXT']
+  Bundler::Definition.prepend(DefinitionPatch)
+end


### PR DESCRIPTION
- Application will be able to enable dualbooting with few lines of
  code instead of having to monkeypatch their Gemfile directly.

  To start with, how to enable dualbooting in your app:
  ```ruby
  # Gemfile

  if Bundler::Plugin.installed?('bootboot')
    $LOAD_PATH << Bundler::Plugin.index.plugin_path('bootboot').join('lib')

    require 'bootboot/enable_dual_booting'
  end
  ```

  Now is the why.

  `Bootboot` is a plugin, it doesn't behave like a regular gem,
  so we need to make a concession to make it available on the LOAD_PATH

  Plugins in Bundler are meant to be executed only in the context of
  the `Plugin#eval_gemfile` which is done when installing gem (i.e.
  when you call `bundle install` or `bundle update`...).

  They aren't meant to be loaded in the $LOAD_PATH when Bundler.setup
  gets called.
  Making Bootboot a plugin is mandatory, we can't specify it as a gem,
  as otherwise the "keep Gemfile_next in sync" feature can't work.

  It's also impossible to have the Gemfile include a module, since
  during Gemfile evaluation time, the $LOAD_PATH is completely empty.