### PR TITLE
Update the `Gemfile.lock` when required:

### DIFF
--- a/lib/bootboot.rb
+++ b/lib/bootboot.rb
@@ -3,8 +3,10 @@ require "bootboot/bundler_patch"
 
 module Bootboot
   GEMFILE = Bundler.default_gemfile
-  GEMFILE_NEXT = Pathname("#{GEMFILE}_next.lock")
-  DUALBOOT_ENV = 'DEPENDENCIES_NEXT'
+  GEMFILE_LOCK = Pathname("#{GEMFILE}.lock")
+  GEMFILE_NEXT_LOCK = Pathname("#{GEMFILE}_next.lock")
+  DUALBOOT_NEXT = 'DEPENDENCIES_NEXT'
+  DUALBOOT_PREVIOUS = 'DEPENDENCIES_PREVIOUS'
 
   autoload :GemfileNextAutoSync, 'bootboot/gemfile_next_auto_sync'
   autoload :Command,             'bootboot/command'

--- a/lib/bootboot/bundler_patch.rb
+++ b/lib/bootboot/bundler_patch.rb
@@ -2,7 +2,11 @@
 
 module DefinitionPatch
   def initialize(wrong_lock, *args)
-    lockfile = Pathname.new("#{Bundler::SharedHelpers.default_gemfile}_next.lock")
+    lockfile = if ENV['SKIP_BUNDLER_PATCH']
+      wrong_lock
+    else
+      Bootboot::GEMFILE_NEXT_LOCK
+    end
 
     super(lockfile, *args)
   end
@@ -10,7 +14,7 @@ end
 
 module SharedHelpersPatch
   def default_lockfile
-    Pathname.new("#{default_gemfile}_next.lock")
+    Bootboot::GEMFILE_NEXT_LOCK
   end
 end
 

--- a/lib/bootboot/command.rb
+++ b/lib/bootboot/command.rb
@@ -9,7 +9,7 @@ module Bootboot
     end
 
     def exec(_cmd, _args)
-      FileUtils.cp("#{GEMFILE}.lock", GEMFILE_NEXT)
+      FileUtils.cp(GEMFILE_LOCK, GEMFILE_NEXT_LOCK)
 
       File.open(GEMFILE, 'a+') do |f|
         f.write(<<-EOM)
@@ -19,7 +19,7 @@ if ENV['DEPENDENCIES_NEXT']
   enable_dual_booting if Plugin.installed?('bootboot')
 
   # Add any gem you want here, they will be loaded only when running
-  # bundler command prefixed with `#{DUALBOOT_ENV}=1`.
+  # bundler command prefixed with `#{DUALBOOT_NEXT}=1`.
 end
 EOM
       end


### PR DESCRIPTION
- At Shopify, when a dependency upgrade is almost complete, we enable
  the next version of the gem by default on all developers environment

  Our Gemfile then looks something like that

  ```ruby
  unless ENV['DEPENDENCIES_PREVIOUS']
    enable_dual_booting
    gem 'rails', '~> 5.2.0'
  else
    gem 'rails', '~> 5.1.0'
  end
  ```
  This basically translate as "Boot with Rails 5.2.0 unless someone
  puts the `DEPENDENCIES_PREVIOUS` ENV".

  Because by default, the dualboot is enabled, when running `bundle
  update <some_gem>`, the `Gemfile_next.lock` will get updated, not
  the `Gemfile.lock`.

  This PR updates one lock or the other depending on which one was by
  default updated.
  However, if someone run `DEPENDENCIES_NEXT=1 bundle update rails`,
  the other lockfile will not be updated, that's because most likely
  if someone updates the lock witch a bootboot env var set, it means
  he solely wants to update that lock.