### PR TITLE
Add a way to customize the `DEPENDENCIES_NEXT` env:

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,16 @@ Dual boot it!
 ------------
 If you want to boot using the dependencies from the `Gemfile_next.lock`, run any bundler command prefixed with the `DEPENDENCIES_NEXT=1` ENV variable. I.e. `DEPENDENCIES_NEXT=1 bundle exec irb`.
 
+Configuration (Optional)
+------------------------
+By default Bootboot will use the `DEPENDENCIES_NEXT` environment variable to update your Gemfile_next.lock. You can however configure it. For example, if you want the dualboot to happen when the `SHOPIFY_NEXT` env variable is present, you simply have to add this in your Gemfile:
 
-Keep` the Gemfile_next.lock` in sync
+```ruby
+# Gemfile
+Bundler.settings.set_local('booboot_env_previx', 'SHOPIFY')
+```
+
+Keep the `Gemfile_next.lock` in sync
 ------------
 When a developer bumps or adds a dependency, Bootboot will ensure that the `Gemfile_next.lock` snapshot gets updated.
 

--- a/lib/bootboot.rb
+++ b/lib/bootboot.rb
@@ -7,11 +7,25 @@ module Bootboot
   GEMFILE = Bundler.default_gemfile
   GEMFILE_LOCK = Pathname("#{GEMFILE}.lock")
   GEMFILE_NEXT_LOCK = Pathname("#{GEMFILE}_next.lock")
-  DUALBOOT_NEXT = 'DEPENDENCIES_NEXT'
-  DUALBOOT_PREVIOUS = 'DEPENDENCIES_PREVIOUS'
 
   autoload :GemfileNextAutoSync, 'bootboot/gemfile_next_auto_sync'
   autoload :Command,             'bootboot/command'
+
+  class << self
+    def env_next
+      env_prefix + '_NEXT'
+    end
+
+    def env_previous
+      env_prefix + '_PREVIOUS'
+    end
+
+    private
+
+    def env_prefix
+      Bundler.settings['bootboot_env_prefix'] || 'DEPENDENCIES'
+    end
+  end
 end
 
 Bootboot::GemfileNextAutoSync.new.setup

--- a/lib/bootboot/command.rb
+++ b/lib/bootboot/command.rb
@@ -15,11 +15,11 @@ module Bootboot
         f.write(<<-EOM)
 Plugin.send(:load_plugin, 'bootboot') if Plugin.installed?('bootboot')
 
-if ENV['DEPENDENCIES_NEXT']
+if ENV['#{Bootboot.env_next}']
   enable_dual_booting if Plugin.installed?('bootboot')
 
   # Add any gem you want here, they will be loaded only when running
-  # bundler command prefixed with `#{DUALBOOT_NEXT}=1`.
+  # bundler command prefixed with `#{Bootboot.env_next}=1`.
 end
 EOM
       end

--- a/lib/bootboot/gemfile_next_auto_sync.rb
+++ b/lib/bootboot/gemfile_next_auto_sync.rb
@@ -32,8 +32,8 @@ module Bootboot
 
         next if !GEMFILE_NEXT_LOCK.exist? ||
                 nothing_changed?(current_definition) ||
-                ENV[DUALBOOT_NEXT] ||
-                ENV[DUALBOOT_PREVIOUS]
+                ENV[Bootboot.env_next] ||
+                ENV[Bootboot.env_previous]
 
         update!(current_definition)
       end
@@ -62,9 +62,9 @@ module Bootboot
 
     def which_env
       if Bundler.default_lockfile.to_s =~ /_next\.lock/
-        DUALBOOT_PREVIOUS
+        Bootboot.env_previous
       else
-        DUALBOOT_NEXT
+        Bootboot.env_next
       end
     end
 


### PR DESCRIPTION
- Bootboot by default uses `DEPENDENCIES_NEXT` and
  `DEPENDENCIES_PREVIOUS` environment variables to update your
  Gemfile.lock or Gemfile_next.lock.

  This PR adds a way to configure the `DEPENDENCIES` prefix.

  If one wanted to dualboot when `SHOPIFY_NEXT` env is present,
  you can just add `Bundler.settigs.set_local('bootboot_env_prefix', 'SHOPIFY')`
  anywhere in the Gemfile.