### PR TITLE
Fix sentence about `bundle --deployment`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ When a developer bumps or adds a dependency, Bootboot will ensure that the `Gemf
 **However, this feature is only available if you are on Bundler `>= 1.17`**
 Other versions will trigger a warning message telling them that Bootboot can't automatically keep the `Gemfile_next.lock` in sync.
 
-If you use the deployment flag (`bundle --deployment`) this plugin won't work on Bundler `>= 2.0`.
+If you use the deployment flag (`bundle --deployment`) this plugin won't work on Bundler `<= 2.0.1`.


### PR DESCRIPTION
https://github.com/bundler/bundler/pull/6805 was backported to `2-0-stable`
in https://github.com/bundler/bundler/commit/fbab11810635b6c0843446320e7902186c7c715c,
`bundle --deployment` will work since v2.0.2.