### PR TITLE
Patch bundler to allow different rubies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ No matter what approach you decide to take, you'll need to create tooling to ens
 
 Bootboot is only useful if you decide to follow the second approach. It creates the required tooling as well as the Bundler workaround needed to enable dual booting.
 
-
-
 Installation
 ------------
 1) In your Gemfile, add this
@@ -56,6 +54,119 @@ Note: You should only run `bundle bootboot` once to install the plugin, otherwis
 Dual boot it!
 ------------
 If you want to boot using the dependencies from the `Gemfile_next.lock`, run any bundler command prefixed with the `DEPENDENCIES_NEXT=1` ENV variable. I.e. `DEPENDENCIES_NEXT=1 bundle exec irb`.
+
+**Note:** `bootboot` will use the gems and Ruby version specified per environment in your `Gemfile` to resolve dependencies and keep `Gemfile.lock` and `Gemfile_next.lock` in sync, but it does not do any magic to actually change the running Ruby version or install the gems in the environment you are not currently running, it simply tells Bundler which Ruby and gem versions to use in its resolution algorithm and keeps the lock files in sync. If you are a developer who is not involved in updating the dependency set, this should not affect you, simply use bundler normally. _However_, if you are involved in the dependency changes directly, you will often have to run `DEPENDENCIES_NEXT=1 bundle install` after making changes to the dependencies.
+
+```sh
+# This will update Gemfile.lock and Gemfile_next.lock and install the gems
+# specified in Gemfile.lock:
+$ bundle update some_gem
+# This will actually install the gems specified in Gemfile_next.lock
+$ DEPENDENCIES_NEXT=1 bundle install
+```
+
+Dual boot different Ruby versions
+---------------------------------
+
+While dual booting is often used for framework upgrades, it is also possible to use `bootboot` to dual boot two Ruby versions, each with its own set of gems.
+
+```ruby
+# Gemfile
+
+if ENV['DEPENDENCIES_NEXT']
+  ruby '2.6.5'
+else
+  ruby '2.5.7'
+end
+```
+
+Dual booting Ruby versions does incur some additional complications however, see the examples following for more detail.
+
+Example: updating a gem while dual booting Ruby versions
+--------------------------------------------------------
+
+To dual boot an app while upgrading from Ruby 2.5.7 to Ruby 2.6.5, your Gemfile would look like this:
+
+```ruby
+# Gemfile
+
+if ENV['DEPENDENCIES_NEXT']
+  ruby '2.6.5'
+else
+  ruby '2.5.7'
+end
+```
+
+After running `bundle install`, `Gemfile.lock` will have:
+
+```
+RUBY VERSION
+   ruby 2.5.7p206
+```
+
+and `Gemfile_next.lock` will have:
+
+```
+RUBY VERSION
+   ruby 2.6.5p114
+```
+Assuming there's a gem `some_gem` with the following constraints in its gemspecs:
+
+```ruby
+# some_gem-1.0.gemspec
+spec.version = "1.0"
+spec.required_ruby_version = '>= 2.5.7'
+```
+
+```ruby
+# some_gem-2.0.gemspec
+spec.version = "2.0"
+spec.required_ruby_version = '>= 2.6.5'
+```
+
+Running `bundle update some_gem` will use Ruby 2.5.7 to resolve `some_gem` for `Gemfile.lock` and Ruby 2.6.5 to resolve `some_gem` for `Gemfile_next.lock` with the following results:
+
+Gemfile.lock:
+```
+specs:
+  some_gem (1.0)
+```
+
+Gemfile_next.lock:
+```
+specs:
+  some_gem (2.0)
+```
+
+**Note:** It is important to note that at this point, `some_gem 2.0` **will not** be installed on your system, it will simply be specified in `Gemfile_next.lock`, since installing it on the system would require changing the running Ruby version. This is sufficient to keep `Gemfile_next.lock` in sync, but is a potential source of confusion. To install gems under both versions of Ruby, see the next section.
+
+### Example: running Ruby scripts while dual booting Ruby versions
+
+When running Ruby scripts while dual booting two different Ruby versions, you have to remember to do two things simultaneously for every command:
+- Run the command with the correct version of Ruby
+- Add the DEPENDENCIES_NEXT environment variable to tell bundler to use `Gemfile_next.lock`
+
+So to run a spec in both versions, the workflow would look like this (assuming chruby for version management):
+
+```sh
+$ chruby 2.5.7
+$ bundle exec rspec spec/some_spec.rb
+$ chruby 2.6.5
+$ DEPENDENCIES_NEXT=1 bundle exec rspec spec/some_spec.rb
+```
+
+Perhaps more importantly, to update or install a gem, the workflow would look like this:
+
+```sh
+# This will update Gemfile.lock and Gemfile_next.lock and install the gems
+# specified in Gemfile.lock:
+$ chruby 2.5.7
+$ bundle update some_gem
+# This will actually install the gems specified in Gemfile_next.lock under the
+# correct Ruby installation:
+$ chruby 2.6.5
+$ DEPENDENCIES_NEXT=1 bundle install
+```
 
 Configuration (Optional)
 ------------------------

--- a/lib/bootboot/bundler_patch.rb
+++ b/lib/bootboot/bundler_patch.rb
@@ -12,20 +12,24 @@ module DefinitionPatch
   end
 end
 
-module RubyVersionPatch
-  def system
-    if ENV['BOOTBOOT_UPDATING_ALTERNATE_LOCKFILE']
-      # If we're updating the alternate file and the ruby version specified in
-      # the Gemfile is different from the Ruby version currently running, we
-      # want to build a definition without a lockfile (so that `ruby_version`
-      # in the Gemfile isn't overridden by the lockfile) and get its
-      # `ruby_version`. This will be used both during dependency resolution so
-      # that we can pretend that intended Ruby version is present, as well as
-      # when updating the lockfile itself.
-      Bundler::Definition.build(Bootboot::GEMFILE, nil, false).ruby_version || super
-    else
-      super
+module MetadataPatch
+  def specs
+    metadata_specs = super
+
+    # The spec name for Ruby changed between Bundler 1.17 and 2.0, so we
+    # want to get the Ruby spec name that the definition is depending on
+    ruby_spec = metadata_specs.find { |d| d.name[/[R|r]uby\0/] }
+    alternate_ruby_version = Bundler::Definition.build(Bootboot::GEMFILE, nil, false).ruby_version
+
+    if ruby_spec && alternate_ruby_version && alternate_ruby_version != Bundler::RubyVersion.system
+      specs_with_ruby = metadata_specs.dup
+      ruby_spec = Gem::Specification.new(ruby_spec.name, alternate_ruby_version.to_gem_version_with_patchlevel)
+      ruby_spec.source = self
+      specs_with_ruby << ruby_spec
+      return specs_with_ruby
     end
+
+    metadata_specs
   end
 end
 
@@ -38,7 +42,7 @@ end
 Bundler::Dsl.class_eval do
   def enable_dual_booting
     Bundler::Definition.prepend(DefinitionPatch)
-    Bundler::RubyVersion.singleton_class.prepend(RubyVersionPatch)
+    Bundler::Source::Metadata.prepend(MetadataPatch)
     Bundler::SharedHelpers.singleton_class.prepend(SharedHelpersPatch)
   end
 end

--- a/lib/bootboot/bundler_patch.rb
+++ b/lib/bootboot/bundler_patch.rb
@@ -2,13 +2,30 @@
 
 module DefinitionPatch
   def initialize(wrong_lock, *args)
-    lockfile = if ENV['SKIP_BUNDLER_PATCH']
+    lockfile = if ENV['BOOTBOOT_UPDATING_ALTERNATE_LOCKFILE']
       wrong_lock
     else
       Bootboot::GEMFILE_NEXT_LOCK
     end
 
     super(lockfile, *args)
+  end
+end
+
+module RubyVersionPatch
+  def system
+    if ENV['BOOTBOOT_UPDATING_ALTERNATE_LOCKFILE']
+      # If we're updating the alternate file and the ruby version specified in
+      # the Gemfile is different from the Ruby version currently running, we
+      # want to build a definition without a lockfile (so that `ruby_version`
+      # in the Gemfile isn't overridden by the lockfile) and get its
+      # `ruby_version`. This will be used both during dependency resolution so
+      # that we can pretend that intended Ruby version is present, as well as
+      # when updating the lockfile itself.
+      Bundler::Definition.build(Bootboot::GEMFILE, nil, false).ruby_version || super
+    else
+      super
+    end
   end
 end
 
@@ -21,6 +38,7 @@ end
 Bundler::Dsl.class_eval do
   def enable_dual_booting
     Bundler::Definition.prepend(DefinitionPatch)
+    Bundler::RubyVersion.singleton_class.prepend(RubyVersionPatch)
     Bundler::SharedHelpers.singleton_class.prepend(SharedHelpersPatch)
   end
 end

--- a/lib/bootboot/gemfile_next_auto_sync.rb
+++ b/lib/bootboot/gemfile_next_auto_sync.rb
@@ -49,7 +49,7 @@ module Bootboot
 
       Bundler.ui.confirm("Updating the #{lock}")
       ENV[env] = '1'
-      ENV['SKIP_BUNDLER_PATCH'] = '1'
+      ENV['BOOTBOOT_UPDATING_ALTERNATE_LOCKFILE'] = '1'
 
       unlock = current_definition.instance_variable_get(:@unlock)
       definition = Bundler::Definition.build(GEMFILE, lock, unlock)
@@ -57,7 +57,7 @@ module Bootboot
       definition.lock(lock)
     ensure
       ENV.delete(env)
-      ENV.delete('SKIP_BUNDLER_PATCH')
+      ENV.delete('BOOTBOOT_UPDATING_ALTERNATE_LOCKFILE')
     end
 
     def which_env

--- a/lib/bootboot/ruby_source.rb
+++ b/lib/bootboot/ruby_source.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Bootboot
+  class RubySource
+    include Bundler::Plugin::API::Source
+
+    # The spec name for Ruby changed from "ruby\0" to "Ruby\0" between Bundler
+    # 1.17 and 2.0, so we want to use the Ruby spec name from Metadata so
+    # Bootboot works across Bundler versions
+    def ruby_spec_name
+      @ruby_spec_name ||= begin
+        metadata = Bundler::Source::Metadata.new
+        ruby_spec = metadata.specs.find { |s| s.name[/[R|r]uby\0/] }
+        # Default to Bundler > 2 in case the Bundler internals change
+        ruby_spec ? ruby_spec.name : "Ruby\0"
+      end
+    end
+
+    def specs
+      Bundler::Index.build do |idx|
+        # If the ruby version specified in the Gemfile is different from the
+        # Ruby version currently running, we want to build a definition without
+        # a lockfile (so that `ruby_version` in the Gemfile isn't overridden by
+        # the lockfile) and get its `ruby_version`. This will be used both
+        # during dependency resolution so that we can pretend the intended Ruby
+        # version is present, as well as when updating the lockfile itself.
+        ruby_version = Bundler::Definition.build(Bootboot::GEMFILE, nil, false).ruby_version
+        ruby_version ||= Bundler::RubyVersion.system
+        ruby_spec = Gem::Specification.new(ruby_spec_name, ruby_version.to_gem_version_with_patchlevel)
+        ruby_spec.source = self
+        idx << ruby_spec
+      end
+    end
+
+    def to_s
+      "Bootboot plugin Ruby source"
+    end
+  end
+end

--- a/test/bootboot_test.rb
+++ b/test/bootboot_test.rb
@@ -226,7 +226,7 @@ class BootbootTest < Minitest::Test
         RUBY_VERSION,
         Bundler::Definition.build(
           file.path, "#{file.path}.lock", false
-        ).ruby_version.gem_version.to_s
+        ).locked_ruby_version_object.gem_version.to_s
       )
 
       with_env_next do
@@ -234,38 +234,7 @@ class BootbootTest < Minitest::Test
           "9.9.9",
           Bundler::Definition.build(
             file.path, gemfile_next(file), false
-          ).ruby_version.gem_version.to_s
-        )
-      end
-    end
-  end
-
-  def test_bundle_install_with_different_ruby_updating_gemfile_lock_succeeds
-    write_gemfile do |file, _dir|
-      FileUtils.cp("#{file.path}.lock", gemfile_next(file))
-      File.write(file, <<-EOM, mode: 'a')
-        if ENV['DEPENDENCIES_NEXT']
-          ruby '#{RUBY_VERSION}'
-        else
-          ruby '0.0.0'
-        end
-      EOM
-
-      run_bundler_command('bundle install', file.path, env: { Bootboot.env_next => '1' })
-
-      assert_equal(
-        "0.0.0",
-        Bundler::Definition.build(
-          file.path, "#{file.path}.lock", false
-        ).ruby_version.gem_version.to_s
-      )
-
-      with_env_next do
-        assert_equal(
-          RUBY_VERSION,
-          Bundler::Definition.build(
-            file.path, gemfile_next(file), false
-          ).ruby_version.gem_version.to_s
+          ).locked_ruby_version_object.gem_version.to_s
         )
       end
     end

--- a/test/bootboot_test.rb
+++ b/test/bootboot_test.rb
@@ -209,6 +209,54 @@ class BootbootTest < Minitest::Test
     end
   end
 
+  def test_bundle_install_with_different_ruby_updating_gemfile_next_lock_succeeds
+    write_gemfile do |file, _dir|
+      FileUtils.cp("#{file.path}.lock", gemfile_next(file))
+      File.write(file, <<-EOM, mode: 'a')
+        if ENV['DEPENDENCIES_NEXT']
+          ruby '9.9.9'
+        else
+          ruby '#{RUBY_VERSION}'
+        end
+      EOM
+
+      run_bundler_command('bundle install', file.path)
+
+      assert_equal(
+        RUBY_VERSION,
+        Bundler::Definition.build(
+          file.path, "#{file.path}.lock", false
+        ).ruby_version.gem_version.to_s
+      )
+
+      with_env_next do
+        assert_equal(
+          "9.9.9",
+          Bundler::Definition.build(
+            file.path, gemfile_next(file), false
+          ).ruby_version.gem_version.to_s
+        )
+      end
+    end
+  end
+
+  def test_bundle_install_with_different_ruby_for_installing_gemfile_next_lock_fails
+    write_gemfile do |file, _dir|
+      FileUtils.cp("#{file.path}.lock", gemfile_next(file))
+      File.write(file, <<-EOM, mode: 'a')
+        if ENV['DEPENDENCIES_NEXT']
+          ruby '9.9.9'
+        else
+          ruby '#{RUBY_VERSION}'
+        end
+      EOM
+
+      assert_raises BundleInstallError do
+        run_bundler_command('bundle install', file.path, env: { Bootboot.env_next => '1' })
+      end
+    end
+  end
+
   private
 
   def gemfile_next(gemfile)
@@ -244,13 +292,23 @@ class BootbootTest < Minitest::Test
     "plugin 'bootboot', git: '#{Bundler.root}', branch: '#{branch}'"
   end
 
+  class BundleInstallError < StandardError; end
+
   def run_bundler_command(command, gemfile_path, env: {})
     output = nil
     Bundler.with_clean_env do
       output, status = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile_path }.merge(env), command)
 
-      raise StandardError, "bundle install failed: #{output}" unless status.success?
+      raise BundleInstallError, "bundle install failed: #{output}" unless status.success?
     end
     output
+  end
+
+  def with_env_next
+    prev = ENV[Bootboot.env_next]
+    ENV[Bootboot.env_next] = "1"
+    yield
+  ensure
+    ENV[Bootboot.env_next] = prev
   end
 end

--- a/test/bootboot_test.rb
+++ b/test/bootboot_test.rb
@@ -229,12 +229,20 @@ class BootbootTest < Minitest::Test
         ).ruby_version.gem_version.to_s
       )
 
+      error_message = <<~EOE
+        Running `bundle install` with a version of Ruby other than the one
+        specified in Gemfile_next.lock should update Gemfile_next.lock so that
+        gems are properly resolved using the Ruby version specified in the
+        respective lockfile regardless of the running Ruby version.
+      EOE
+
       with_env_next do
         assert_equal(
           "9.9.9",
           Bundler::Definition.build(
             file.path, gemfile_next(file), false
-          ).ruby_version.gem_version.to_s
+          ).ruby_version.gem_version.to_s,
+          error_message
         )
       end
     end
@@ -251,7 +259,13 @@ class BootbootTest < Minitest::Test
         end
       EOM
 
-      assert_raises BundleInstallError do
+      error_message = <<~EOE
+        Running `DEPENDENCIES_NEXT=1 bundle install` with a version of Ruby
+        other than the one specified in Gemfile_next.lock should fail so that
+        gems are not installed under the wrong Ruby.
+      EOE
+
+      assert_raises BundleInstallError, error_message do
         run_bundler_command('bundle install', file.path, env: { Bootboot.env_next => '1' })
       end
     end


### PR DESCRIPTION
This allows using bootboot for dual booting different versions of Ruby.
For example:

```ruby
source "https://rubygems.org"

plugin 'bootboot'
Plugin.send(:load_plugin, 'bootboot') if Plugin.installed?('bootboot')

if ENV['DEPENDENCIES_NEXT']
  enable_dual_booting if Plugin.installed?('bootboot')
  ruby '2.5.7'
else
  ruby '2.4.9'
end
```

I updated the env var from `SKIP_BUNDLER_PATCH` to `BOOTBOOT_UPDATING_ALTERNATE_LOCKFILE` because I thought it would be confusing if the `RubyVersion` patch took effect when that var was present, which is what needs to happen.