### PR TITLE
Update development bundler to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 cache: bundler
 language: ruby
+rvm:
+  - 2.5.7
+before_install:
+  - gem install bundler -v 2.1.4
 script:
   - bundle exec rubocop --config .rubocop.yml
   - bundle exec rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,11 +56,10 @@ PLATFORMS
 
 DEPENDENCIES
   bootboot!
-  bundler (~> 1.17)
   minitest (~> 5.0)
   package_cloud
   rake
   rubocop
 
 BUNDLED WITH
-   1.17.1
+   2.1.4

--- a/bootboot.gemspec
+++ b/bootboot.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = %w(lib)
 
-  spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/test/bootboot_test.rb
+++ b/test/bootboot_test.rb
@@ -246,7 +246,7 @@ class BootbootTest < Minitest::Test
 
   def run_bundler_command(command, gemfile_path, env: {})
     output = nil
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       output, status = Open3.capture2e({ 'BUNDLE_GEMFILE' => gemfile_path }.merge(env), command)
 
       raise StandardError, "bundle install failed: #{output}" unless status.success?


### PR DESCRIPTION
- Update development bundler to 2.1.4, which is currently the latest version of bundler. There is no particular reason this version of bundler was chosen, but in order to fix Travis (see next), the most straightforward solution was to install a specific bundler version on Travis, and it seemed that the latest version was the most obvious choice.
- The Ruby and bundler versions were not specified for Travis, so the fact that Gemfile.lock required a specific version of bundler was causing errors in CI. This PR pins the Ruby and bundler versions so that the Gemfile.lock matches what is installed. If it is desired, Travis also supports running multiple dependency sets so that bootboot could be run against many versions of bundler.
- Remove bundler from gemspec. Since the version of bundler is pinned in Gemfile.lock, it isn't necessary to specify bundler as a development dependency, and removing it removes the duplication of versions between Gemfile.lock and the gemspec. Maybe it makes sense to have this in the gemspec though, it just seemed unecessary since in almost all cases, bundler will have to be installed already to resolve the gemspec.
- Update a deprecated API