### PR TITLE
Ability to vendor dependencies with bootboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#32](https://github.com/Shopify/bootboot/pull/32): Add a way to allow caching of two sets of gems. (@janschill)
+
 ## 0.1.2 (2019-01-09)
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ specs:
 
 **Note:** It is important to note that at this point, `some_gem 2.0` **will not** be installed on your system, it will simply be specified in `Gemfile_next.lock`, since installing it on the system would require changing the running Ruby version. This is sufficient to keep `Gemfile_next.lock` in sync, but is a potential source of confusion. To install gems under both versions of Ruby, see the next section.
 
+Vendoring both sets of gems
+---------------------------
+To vendor both sets of gems, make sure caching is enabled by checking `bundle config` or bundle gems using `bundle pack`.
+
+```bash
+bundle pack
+DEPENDENCIES_NEXT=1 bundle pack
+```
+
 ### Example: running Ruby scripts while dual booting Ruby versions
 
 When running Ruby scripts while dual booting two different Ruby versions, you have to remember to do two things simultaneously for every command:

--- a/lib/bootboot/bundler_patch.rb
+++ b/lib/bootboot/bundler_patch.rb
@@ -52,5 +52,10 @@ Bundler::Dsl.class_eval do
   def enable_dual_booting
     Bundler::Definition.prepend(DefinitionPatch)
     Bundler::SharedHelpers.singleton_class.prepend(SharedHelpersPatch)
+    Bundler::Settings.prepend(Module.new do
+      def app_cache_path
+        'vendor/cache-next'
+      end
+    end)
   end
 end


### PR DESCRIPTION
When trying out bootboot I ran into the issue that I need to cache both sets of gems. I saw that there has been some discussion to this topic here: https://github.com/Shopify/bootboot/issues/29.

I am new to Ruby and am open to critique or suggestions. Go easy on me :wink:
Appends -next to the current Bundler.app_cache path when caching is used, so that users can work with the two different vendored versions simultaneously.