### PR TITLE
Update gemspec to exclude unnecessary files

### DIFF
--- a/bootboot.gemspec
+++ b/bootboot.gemspec
@@ -24,9 +24,8 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/shopify/bootboot"
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/bootboot/blob/master/CHANGELOG.md"
 
-  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
-    %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files = %x(git ls-files lib plugins.rb README.md LICENSE.txt).split($RS)
+  spec.extra_rdoc_files = ['LICENSE.txt', 'README.md']
   spec.require_paths = %w(lib)
 
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The next bundled version of the gem will only include the files necessary to run it. Excluding files like the `.rubocopy.yml` and `.travis.yml`

It's a nice to have when caching the plugin manually to get around the fact that caching isn't supported for bundler plugins yet.

For folks looking to install and run this plugin from a vendored/cached location while the issues outlined in https://github.com/rubygems/bundler/issues/7152 are resolved, you can do so with `gem unpack bootboot -v 0.1.2 --target vendor/plugins/` and

```ruby
# Gemfile

if ENV['DEPENDENCIES_NEXT']
  Bundler.rubygems.add_to_load_path('vendor/plugins/bootboot-0.1.2/lib')
  load('vendor/plugins/bootboot-0.1.2/plugins.rb')
  enable_dual_booting

  gem 'future'
else
  gem 'present'
end
```