### PR TITLE
Fix Bundler::Plugin.load_plugin on first install

### DIFF
--- a/lib/bootboot.rb
+++ b/lib/bootboot.rb
@@ -20,6 +20,13 @@ module Bootboot
       env_prefix + '_PREVIOUS'
     end
 
+    def load
+      return if Bundler::Plugin.instance_variable_get(:@loaded_plugin_names).include?('bootboot')
+
+      GemfileNextAutoSync.new.setup
+      Command.new.setup
+    end
+
     private
 
     def env_prefix
@@ -27,6 +34,3 @@ module Bootboot
     end
   end
 end
-
-Bootboot::GemfileNextAutoSync.new.setup
-Bootboot::Command.new.setup

--- a/lib/bootboot/gemfile_next_auto_sync.rb
+++ b/lib/bootboot/gemfile_next_auto_sync.rb
@@ -24,7 +24,9 @@ module Bootboot
 
     def opt_in
       self.class.hook('before-install-all') do
-        @previous_lock = Bundler.default_lockfile.read
+        if Bundler.default_lockfile.exist?
+          @previous_lock = Bundler.default_lockfile.read
+        end
       end
 
       self.class.hook("after-install-all") do

--- a/plugins.rb
+++ b/plugins.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.expand_path("../lib", __FILE__))
-require "bootboot"
+require_relative "lib/bootboot"
 Bootboot.load

--- a/plugins.rb
+++ b/plugins.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "lib/bootboot"
+$LOAD_PATH.unshift(File.expand_path("../lib", __FILE__))
+require "bootboot"
+Bootboot.load

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-require "bootboot"
-
+require_relative "../plugins"
 require "minitest/autorun"


### PR DESCRIPTION
If `bundle install` is run before bootboot has been installed, `Gemfile_next.lock` is not correctly synced.

There is currently a bug (which is reproducible by running the test included on `master`) where if the `Gemfile` is changed before `bootboot` has been installed, `Gemfile_next.lock` doesn't get updated. In other words, if someone clones a project that already uses `bootboot` and has a `Gemfile_next.lock`, then they add a gem to `Gemfile` without first running `bundle install`, when they then run `bundle install` (for the first time), the added gem will not appear in `Gemfile_next.lock`. The issue is that Bundler expects to be able to load `plugins.rb` multiple times, first in `register_plugin` and again in `load_plugin` and it erases state in between, but `bootboot` uses `require` in `plugins.rb` so the hooks are removed in `register_plugin` but not re-added in `load_plugin` since `require` does not reload `bootboot.rb`. The sequence diagrams below demonstrate simplified "before" and "after" call sequences.

## Before

<img width="1763" alt="before" src="https://user-images.githubusercontent.com/1620230/75193073-83819180-5723-11ea-8713-3db6d24e9bc9.png">

## After

<img width="1707" alt="after" src="https://user-images.githubusercontent.com/1620230/75193092-89777280-5723-11ea-9006-8af98d648102.png">
