### PR TITLE
Run multiple Rubies and bundlers in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
-sudo: false
 cache: bundler
 language: ruby
+env:
+  - "BOOTBOOT_TEST_BUNDLER_VERSION=1.17.3"
+  - "BOOTBOOT_TEST_BUNDLER_VERSION=2.0.2"
+  - "BOOTBOOT_TEST_BUNDLER_VERSION=2.1.4"
 rvm:
-  - 2.5.7
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
 before_install:
-  - gem install bundler -v 2.1.4
+  - yes | gem update --system --force
+  - gem install bundler -v "$BOOTBOOT_TEST_BUNDLER_VERSION"
 script:
   - bundle exec rubocop --config .rubocop.yml
   - bundle exec rake test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+ENV["BOOTBOOT_TEST_BUNDLER_VERSION"] ||= Bundler::VERSION
+puts "Running tests using Bundler #{ENV['BOOTBOOT_TEST_BUNDLER_VERSION']}"
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "bootboot"
 


### PR DESCRIPTION
Using the Travis build matrix, this runs the tests using 3 versions of bundler and 4 versions of Ruby. The reason I think this would be a nice addition is because bootboot uses several unstable/private APIs, including reading instance variables like `definition.instance_variable_get(:@unlock)`. Running the test suite on many versions of bundler would reduce the risk of a Bundler change breaking bootboot.

I'm not sure if this addition is welcome since it could increase the runtime of the test suite on CI. Supposedly there is a limit of 200 concurrent jobs, but it looks like Travis will only run about 5 jobs in parallel, but maybe I have something misconfigured.

Maybe running on many Ruby versions is not as valuable as running on many Bundler versions, so if you like the idea but not the number of jobs, it'd be easy to run all the versions of bundler but only one version of Ruby.