### PR TITLE
Stop using `Bundler::RubyVersion#to_gem_version_with_patchlevel`

### DIFF
--- a/lib/bootboot/ruby_source.rb
+++ b/lib/bootboot/ruby_source.rb
@@ -26,7 +26,7 @@ module Bootboot
         # version is present, as well as when updating the lockfile itself.
         ruby_version = Bundler::Definition.build(Bootboot::GEMFILE, nil, false).ruby_version
         ruby_version ||= Bundler::RubyVersion.system
-        ruby_spec = Gem::Specification.new(ruby_spec_name, ruby_version.to_gem_version_with_patchlevel)
+        ruby_spec = Gem::Specification.new(ruby_spec_name, ruby_version.gem_version)
         ruby_spec.source = self
         idx << ruby_spec
       end


### PR DESCRIPTION
This method reports the patch level of Ruby, which is no longer useful since Ruby 2.0.0, and was causing Bundler to show some strange error messages about Ruby version with 4 segments, like 3.1.1.0.

The method was removed too aggressively from Bundler without knowing that it was actually being used by bootboot. Depending on how widely it's actually used, we might restore it with a deprecation, but this commit makes bootboot use a better method.