### PR TITLE
Update version shown in readme installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Installation
 ------------
 1) In your Gemfile, add this
 ```ruby
-plugin 'bootboot', '~> 0.1.1'
+plugin 'bootboot', '~> 0.2.1'
 ```
 2) Run `bundle install && bundle bootboot`
 3) You're done. Commit the Gemfile and the Gemfile_next.lock


### PR DESCRIPTION
There have been a few releases since 0.1.1. Keeping the installation instructions mildly up to date may help some folks avoid problems with older versions.