### PR TITLE
Drop support for Ruby 2.7, 3.0, and 3.1 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-        bundler: latest
     - name: Ruby Tests
       run: bundle exec rake test
     - name: RuboCop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.2", "3.3"]
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,12 @@ gemspec
 
 gem "rubocop-shopify", require: false
 
-group :deployment do
+group :deployment, :development do
   gem "rake"
+end
+
+group :development do
+  gem "minitest"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,4 +48,4 @@ DEPENDENCIES
   rubocop-shopify
 
 BUNDLED WITH
-   2.5.7
+   2.7.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     ast (2.4.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    minitest (5.17.0)
+    minitest (5.26.2)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -42,7 +42,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootboot!
-  minitest (~> 5.0)
+  minitest
   rake
   rubocop
   rubocop-shopify

--- a/bootboot.gemspec
+++ b/bootboot.gemspec
@@ -30,7 +30,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.7.0"
-
-  spec.add_development_dependency("minitest", "~> 5.0")
-  spec.add_development_dependency("rake", "~> 10.0")
 end

--- a/test/bootboot_test.rb
+++ b/test/bootboot_test.rb
@@ -66,7 +66,7 @@ class BootbootTest < Minitest::Test
         Bundler.settings.set_local('bootboot_env_prefix', 'SHOPIFY')
 
         if ENV['SHOPIFY_NEXT']
-          gem 'minitest', '5.15.0'
+          gem 'minitest', '5.26.0'
         end
       EOM
 
@@ -79,7 +79,7 @@ class BootbootTest < Minitest::Test
         env: { "SHOPIFY_NEXT" => "1" },
       )
 
-      assert_equal("5.15.0", output.strip)
+      assert_equal("5.26.0", output.strip)
     end
   end
 
@@ -194,7 +194,7 @@ class BootbootTest < Minitest::Test
 
       File.write(file, <<-EOM, mode: "a")
         if ENV['DEPENDENCIES_NEXT']
-          gem 'minitest', '5.15.0'
+          gem 'minitest', '5.25.0'
         end
       EOM
 
@@ -205,7 +205,7 @@ class BootbootTest < Minitest::Test
         env: { "DEPENDENCIES_NEXT" => "1" },
       )
 
-      assert_equal("5.15.0", output.strip)
+      assert_equal("5.25.0", output.strip)
     end
   end
 


### PR DESCRIPTION
Currently, CI tests are broken: https://github.com/Shopify/bootboot/actions/runs/18923984894/job/54026845459

I tried to solve this and found that we need to drop support for obsolete Rubies to achieve a clean solution. This pull request did:

- Fix a warning for gem location https://github.com/Shopify/bootboot/commit/59311ddc92e95b455263439048b5bc94ca720923
- Fix warnings about "already initialized constant", which needs an upgrade of Bundler https://github.com/Shopify/bootboot/commit/7208feed94762da0c572d2091209ee04cc75521b
    - and this also needs newer Rubies
- Fix a warning about mutex_m https://github.com/Shopify/bootboot/commit/694e025ac9527cef7bc5c4db28b7f7bf0311324f
- Fix "can't find gem bundler with executable bundle" errors, caused by Bundler version mismatch https://github.com/Shopify/bootboot/commit/39c0015a6cc69f799e84e549c0bc1400f1282a50

The above warnings cause some test cases to fail because they generate warning messages.

This is technically a breaking change, though I believe that no big issues will occur when using bootboot with older Rubies.