### PR TITLE
fix: $RS is not defined

### DIFF
--- a/bootboot.gemspec
+++ b/bootboot.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/bootboot/blob/master/CHANGELOG.md"
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.files = %x(git ls-files -z lib plugins.rb README.md LICENSE.txt).split("\x0")
+  spec.files = Dir["lib/**/*", "LICENSE.txt", "README.md", "plugins.rb"]
   spec.extra_rdoc_files = ["LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 

--- a/bootboot.gemspec
+++ b/bootboot.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/bootboot/blob/master/CHANGELOG.md"
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.files = %x(git ls-files lib plugins.rb README.md LICENSE.txt).split($RS)
+  spec.files = %x(git ls-files -z lib plugins.rb README.md LICENSE.txt).split("\x0")
   spec.extra_rdoc_files = ["LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
`$RS` is defined in `English` module. I suppose that `$RS` was introduced here for Style/SpecialGlobalVars cop of RuboCop, but the module is not required here.

Instead of using the input record separator, this patch uses <del>the NUL character as a separator.</del> a simple file list.